### PR TITLE
Fix bugs in RL trainer

### DIFF
--- a/src/generator/code_search_generator.py
+++ b/src/generator/code_search_generator.py
@@ -156,6 +156,15 @@ def init_and_run(
     messages = list(map(lambda event: event.model_dump(), conversation.state.events))
     final_message = get_agent_final_response(conversation.state.events)
 
+    # remove the workspace dir
+    try:
+        if workspace.exists():
+            os.system(f"rm -rf {str(workspace)}")
+            logger.info(f"Removed workspace {str(workspace)}")
+    except Exception as e:
+        logger.error(f"Error removing workspace {str(workspace)}: {e}", exc_info=True)
+
+
     conversation.close()
     logger.info("Conversation Finished")
 
@@ -311,13 +320,11 @@ class CodeSearchGenerator(SkyRLGymGenerator):
 
         token_messages = [msg for msg in messages if msg["kind"] == "TokenEvent"]
         rollout_list = []
-        gamma = 0.9
-        num_steps = len(token_messages)
         if len(token_messages) > 0:
             for idx, message in enumerate(token_messages):
                 current_prompt_ids = message["prompt_token_ids"]
                 current_response_ids = message["response_token_ids"]
-                step_reward = reward * gamma**(num_steps - idx - 1)
+                step_reward = reward
 
                 rollout_list.append(
                     (

--- a/src/prompts/prompt_builder.py
+++ b/src/prompts/prompt_builder.py
@@ -22,10 +22,9 @@ def get_instruction(
     # Prepare context for rendering
     context = {
         "instance": instance,
-        "workspace_dir_name": workspace_dir_name,
-        "actual_workspace_path": workspace_path,
+        "working_dir": workspace_path,
     }
-    context["test_instructions"] = ""
+    # context["test_instructions"] = ""
 
     # Render the instruction
     instruction = template.render(context)

--- a/src/prompts/templates/default.j2
+++ b/src/prompts/templates/default.j2
@@ -1,4 +1,4 @@
-I have access to a python code repository in the directory {{ instance.repo_path }} . 
+I have access to a python code repository in the directory {{ working_dir }} . 
 
 Consider the following issue description:
 

--- a/src/prompts/templates/file_localization.j2
+++ b/src/prompts/templates/file_localization.j2
@@ -1,4 +1,4 @@
-I have access to a python code repository in the directory {{ instance.repo_path }} . 
+I have access to a python code repository in the directory {{ working_dir }} . 
 
 Consider the following issue description:
 

--- a/src/prompts/templates/file_module.j2
+++ b/src/prompts/templates/file_module.j2
@@ -1,4 +1,4 @@
-I have access to a python code repository in the directory {{ instance.repo_path }} . Consider the following issue description:
+I have access to a python code repository in the directory {{ working_dir }} . Consider the following issue description:
 
 <issue_description>
 {{ instance.problem_statement }}

--- a/src/prompts/templates/file_module_parallel_tools.j2
+++ b/src/prompts/templates/file_module_parallel_tools.j2
@@ -1,4 +1,4 @@
-I have access to a python code repository in the directory {{ instance.repo_path }} . Consider the following issue description:
+I have access to a python code repository in the directory {{ working_dir }} . Consider the following issue description:
 
 <issue_description>
 {{ instance.problem_statement }}

--- a/src/rewards/file_localization/file_localization.py
+++ b/src/rewards/file_localization/file_localization.py
@@ -6,11 +6,12 @@ from src.rewards import reward
 
 def compute_file_f1_score(predicted_files, true_files):
     pred, true = set(predicted_files), set(true_files)
+    if not true:
+        return 0.0 # return 0 reward if ground truth is empty
     tp = len(pred & true)
     precision = tp / len(pred) if pred else 0.0
     recall = tp / len(true) if true else 0.0
-    if not pred and not true:
-        return 1.0
+
     return 0.0 if precision + recall == 0 else 2 * precision * recall / (precision + recall)
 
 # def file_localization_f1_reward(final_message, instance):


### PR DESCRIPTION
The following bugs have been fixed:
- The user prompt template is rendered incorrectly. In current code, the agent will never know where the repo is clone.
- Reward function minor fix: in case the ground truth is empty (say the LocAgent dataset parser could not detect module/entity-level changes) we should give reward of 0 not 1 (not sure if you agree with this but it probably doesn't matter as we use GRPO but matters during eval to prevent incorrect uplifting of metrics).
- Workspace cleanup (important): since many of us run in Babel with a shared /tmp/, we should remove the locally cloned repos. These are pretty large in size O(20GB) and the space will keep decreasing as training proceeds.